### PR TITLE
fix: Mikro-ORM 6.4.6

### DIFF
--- a/backend/src/entities/classes/class-join-request.entity.ts
+++ b/backend/src/entities/classes/class-join-request.entity.ts
@@ -1,6 +1,6 @@
 import { Entity, Enum, ManyToOne } from '@mikro-orm/core';
-import { Student } from '../users/student.entity';
-import { Class } from './class.entity';
+import { Student } from '../users/student.entity.js';
+import { Class } from './class.entity.js';
 
 @Entity()
 export class ClassJoinRequest {

--- a/backend/src/entities/questions/answer.entity.ts
+++ b/backend/src/entities/questions/answer.entity.ts
@@ -1,6 +1,6 @@
 import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
-import { Question } from './question.entity';
-import { Teacher } from '../users/teacher.entity';
+import { Question } from './question.entity.js';
+import { Teacher } from '../users/teacher.entity.js';
 
 @Entity()
 export class Answer {

--- a/backend/src/mikro-orm.config.ts
+++ b/backend/src/mikro-orm.config.ts
@@ -3,15 +3,41 @@ import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { EnvVars, getEnvVar, getNumericEnvVar } from './util/envvars.js';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
-const entities = ['dist/**/*.entity.js'];
-const entitiesTs = ['src/**/*.entity.ts'];
+// Import alle entity-bestanden handmatig
+import { User } from './entities/users/user.entity.js';
+import { Student } from './entities/users/student.entity.js';
+import { Teacher } from './entities/users/teacher.entity.js';
+
+import { Assignment } from './entities/assignments/assignment.entity.js';
+import { Group } from './entities/assignments/group.entity.js';
+import { Submission } from './entities/assignments/submission.entity.js';
+
+import { Class } from './entities/classes/class.entity.js';
+import { ClassJoinRequest } from './entities/classes/class-join-request.entity.js';
+import { TeacherInvitation } from './entities/classes/teacher-invitation.entity.js';
+
+import { Attachment } from './entities/content/attachment.entity.js';
+import { LearningObject } from './entities/content/learning-object.entity.js';
+import { LearningPath } from './entities/content/learning-path.entity.js';
+
+import { Answer } from './entities/questions/answer.entity.js';
+import { Question } from './entities/questions/question.entity.js';
+
+const entities = [
+    User, Student, Teacher,
+    Assignment, Group, Submission,
+    Class, ClassJoinRequest, TeacherInvitation,
+    Attachment, LearningObject, LearningPath,
+    Answer, Question
+];
+
 function config(testingMode: boolean = false): Options {
     if (testingMode) {
         return {
             driver: SqliteDriver,
             dbName: getEnvVar(EnvVars.DbName),
             entities: entities,
-            entitiesTs: entitiesTs,
+            // entitiesTs: entitiesTs,
 
             // Workaround: vitest: `TypeError: Unknown file extension ".ts"` (ERR_UNKNOWN_FILE_EXTENSION)
             // (see https://mikro-orm.io/docs/guide/project-setup#testing-the-endpoint)
@@ -26,7 +52,7 @@ function config(testingMode: boolean = false): Options {
             user: getEnvVar(EnvVars.DbUsername),
             password: getEnvVar(EnvVars.DbPassword),
             entities: entities,
-            entitiesTs: entitiesTs,
+            //entitiesTs: entitiesTs,
             debug: true,
         };
     }


### PR DESCRIPTION
Om de een of andere reden stond er in mijn `package.json` `^6.4.7` in plaats van `6.4.6` of `^6.4.6`.

## Context
Indien je versie `6.4.7` hebt

In /backend:

`rm -rf node_modules package-lock.json`

`npm uninstall @mikro-orm/cli `

`npm install @mikro-orm/cli@6.4.6 @mikro-orm/core@6.4.6 @mikro-orm/postgresql@6.4.6 @mikro-orm/reflection@6.4.6 @mikro-orm/sqlite@6.4.6 --save`

`npm install`

Eventueel ook:

`npm cache clean --force `

## Aanvullende opmerkingen
- Fixes #60 

