### PR TITLE
feat(frontend): Login pagina

### DIFF
--- a/frontend/src/views/LoginPage.vue
+++ b/frontend/src/views/LoginPage.vue
@@ -17,6 +17,8 @@
                         <li class="title">login</li>
                         <li>
                             <v-btn
+                                density="comfortable"
+                                size="large"
                                 class="button"
                                 :to="`/teacher/${userId}`"
                             >
@@ -30,6 +32,8 @@
                         </li>
                         <li>
                             <v-btn
+                                density="comfortable"
+                                size="large"
                                 class="button"
                                 :to="`/student/${userId}`"
                             >
@@ -63,12 +67,11 @@
 
     ul {
         list-style: none;
-        align-items: center;
+        text-align: center;
     }
 
     li {
-        padding: 20px;
-        align-items: center;
+        padding: 10px;
     }
 
     .button {
@@ -77,7 +80,7 @@
 
     .container {
         background-color: white;
-        width: 350px;
+        width: 300px;
         height: 400px;
     }
 


### PR DESCRIPTION
Deze pull request zorgt ervoor dat de login pagina niet meer gewoon wit is. Het dwengo-logo komt erop te staan, als ook twee knoppen om in te loggen afhankelijk van als je als leerkracht of leerling wil inloggen. Deze knoppen verwijzen voorlopig gewoon door naar de *homepages* van de leerkracht of leerling met *id* 1. 

## Context
Net als voordien werd gekozen voor internal CSS om conflicten met globale CSS te vermijden. De knoppen zijn vuetify componenten omdat deze gemakkelijk zijn om mee te werken.

## Screenshots
![image](https://github.com/user-attachments/assets/fa4bf565-0bb3-425c-808c-c69f0323fb63)


## Aanvullende opmerkingen
De login-logica moet nog aangepast worden om met de authenticatie te werken. Dit is momenteel nog niet mogelijk dus ik maak hier een nieuwe issue van. Hetzelfde geldt voor het opvragen van de *id* van de gebruiker die inlogt om de correcte URL te vormen.

- Fixes #26 