### PR TITLE
fix: Opdracht wordt gefetched in originele taal

### DIFF
--- a/frontend/src/views/assignments/StudentAssignment.vue
+++ b/frontend/src/views/assignments/StudentAssignment.vue
@@ -22,8 +22,7 @@
         ) => { groupProgressMap: Map<number, number> };
     }>();
 
-    const { t, locale } = useI18n();
-    const language = ref<Language>(locale.value as Language);
+    const { t } = useI18n();
     const learningPath = ref();
     // Get the user's username/id
     const username = asyncComputed(async () => {
@@ -38,7 +37,7 @@
 
     const lpQueryResult = useGetLearningPathQuery(
         computed(() => assignmentQueryResult.data.value?.assignment?.learningPath ?? ""),
-        computed(() => language.value),
+        computed(() => assignmentQueryResult.data.value?.assignment.language as Language),
     );
 
     const groupsQueryResult = useGroupsQuery(props.classId, props.assignmentId, true);
@@ -100,7 +99,7 @@ language
                     >
                         <v-btn
                             v-if="lpData"
-                            :to="`/learningPath/${lpData.hruid}/${language}/${lpData.startNode.learningobjectHruid}?forGroup=${group?.groupNumber}&assignmentNo=${assignmentId}&classId=${classId}`"
+                            :to="`/learningPath/${lpData.hruid}/${assignmentQueryResult.data.value?.assignment.language}/${lpData.startNode.learningobjectHruid}?forGroup=${group?.groupNumber}&assignmentNo=${assignmentId}&classId=${classId}`"
                             variant="tonal"
                             color="primary"
                         >

--- a/frontend/src/views/assignments/TeacherAssignment.vue
+++ b/frontend/src/views/assignments/TeacherAssignment.vue
@@ -19,8 +19,7 @@ const props = defineProps<{
     ) => { groupProgressMap: Map<number, number> };
 }>();
 
-const {t, locale} = useI18n();
-const language = computed(() => locale.value);
+const {t} = useI18n();
 const groups = ref();
 const learningPath = ref();
 

--- a/frontend/src/views/assignments/TeacherAssignment.vue
+++ b/frontend/src/views/assignments/TeacherAssignment.vue
@@ -1,41 +1,41 @@
 <script setup lang="ts">
-import {computed, type Ref, ref} from "vue";
-import {useI18n} from "vue-i18n";
-import {useAssignmentQuery, useDeleteAssignmentMutation} from "@/queries/assignments.ts";
-import UsingQueryResult from "@/components/UsingQueryResult.vue";
-import {useGroupsQuery} from "@/queries/groups.ts";
-import {useGetLearningPathQuery} from "@/queries/learning-paths.ts";
-import type {Language} from "@/data-objects/language.ts";
-import type {AssignmentResponse} from "@/controllers/assignments.ts";
-import type {GroupDTO} from "@dwengo-1/common/interfaces/group";
+    import { computed, type Ref, ref } from "vue";
+    import { useI18n } from "vue-i18n";
+    import { useAssignmentQuery, useDeleteAssignmentMutation } from "@/queries/assignments.ts";
+    import UsingQueryResult from "@/components/UsingQueryResult.vue";
+    import { useGroupsQuery } from "@/queries/groups.ts";
+    import { useGetLearningPathQuery } from "@/queries/learning-paths.ts";
+    import type { Language } from "@/data-objects/language.ts";
+    import type { AssignmentResponse } from "@/controllers/assignments.ts";
+    import type { GroupDTO } from "@dwengo-1/common/interfaces/group";
 
-const props = defineProps<{
-    classId: string;
-    assignmentId: number;
-    useGroupsWithProgress: (
-        groups: Ref<GroupDTO[]>,
-        hruid: Ref<string>,
-        language: Ref<Language>,
-    ) => { groupProgressMap: Map<number, number> };
-}>();
+    const props = defineProps<{
+        classId: string;
+        assignmentId: number;
+        useGroupsWithProgress: (
+            groups: Ref<GroupDTO[]>,
+            hruid: Ref<string>,
+            language: Ref<Language>,
+        ) => { groupProgressMap: Map<number, number> };
+    }>();
 
-const {t} = useI18n();
-const groups = ref();
-const learningPath = ref();
+    const { t } = useI18n();
+    const groups = ref();
+    const learningPath = ref();
 
-const assignmentQueryResult = useAssignmentQuery(() => props.classId, props.assignmentId);
-learningPath.value = assignmentQueryResult.data.value?.assignment?.learningPath;
-// Get learning path object
-const lpQueryResult = useGetLearningPathQuery(
-    computed(() => assignmentQueryResult.data.value?.assignment?.learningPath ?? ""),
-    computed(() => assignmentQueryResult.data.value?.assignment.language as Language),
-);
+    const assignmentQueryResult = useAssignmentQuery(() => props.classId, props.assignmentId);
+    learningPath.value = assignmentQueryResult.data.value?.assignment?.learningPath;
+    // Get learning path object
+    const lpQueryResult = useGetLearningPathQuery(
+        computed(() => assignmentQueryResult.data.value?.assignment?.learningPath ?? ""),
+        computed(() => assignmentQueryResult.data.value?.assignment.language as Language),
+    );
 
-// Get all the groups withing the assignment
-const groupsQueryResult = useGroupsQuery(props.classId, props.assignmentId, true);
-groups.value = groupsQueryResult.data.value?.groups;
+    // Get all the groups withing the assignment
+    const groupsQueryResult = useGroupsQuery(props.classId, props.assignmentId, true);
+    groups.value = groupsQueryResult.data.value?.groups;
 
-/* Crashes right now cause api data has inexistent hruid TODO: uncomment later and use it in progress bar
+    /* Crashes right now cause api data has inexistent hruid TODO: uncomment later and use it in progress bar
 Const {groupProgressMap} = props.useGroupsWithProgress(
 groups,
 learningPath,
@@ -43,44 +43,44 @@ language
 );
 */
 
-const allGroups = computed(() => {
-    const groups = groupsQueryResult.data.value?.groups;
-    if (!groups) return [];
+    const allGroups = computed(() => {
+        const groups = groupsQueryResult.data.value?.groups;
+        if (!groups) return [];
 
-    return groups.map((group) => ({
-        name: `${t("group")} ${group.groupNumber}`,
-        progress: 0, //GroupProgressMap[group.groupNumber],
-        members: group.members,
-        submitted: false, //TODO: fetch from submission
-    }));
-});
+        return groups.map((group) => ({
+            name: `${t("group")} ${group.groupNumber}`,
+            progress: 0, //GroupProgressMap[group.groupNumber],
+            members: group.members,
+            submitted: false, //TODO: fetch from submission
+        }));
+    });
 
-const dialog = ref(false);
-const selectedGroup = ref({});
+    const dialog = ref(false);
+    const selectedGroup = ref({});
 
-function openGroupDetails(group): void {
-    selectedGroup.value = group;
-    dialog.value = true;
-}
+    function openGroupDetails(group): void {
+        selectedGroup.value = group;
+        dialog.value = true;
+    }
 
-const headers = computed(() => [
-    {title: t("group"), align: "start", key: "name"},
-    {title: t("progress"), align: "center", key: "progress"},
-    {title: t("submission"), align: "center", key: "submission"},
-]);
+    const headers = computed(() => [
+        { title: t("group"), align: "start", key: "name" },
+        { title: t("progress"), align: "center", key: "progress" },
+        { title: t("submission"), align: "center", key: "submission" },
+    ]);
 
-const {mutate} = useDeleteAssignmentMutation();
+    const { mutate } = useDeleteAssignmentMutation();
 
-async function deleteAssignment(num: number, clsId: string): Promise<void> {
-    mutate(
-        {cid: clsId, an: num},
-        {
-            onSuccess: () => {
-                window.location.href = "/user/assignment";
+    async function deleteAssignment(num: number, clsId: string): Promise<void> {
+        mutate(
+            { cid: clsId, an: num },
+            {
+                onSuccess: () => {
+                    window.location.href = "/user/assignment";
+                },
             },
-        },
-    );
-}
+        );
+    }
 </script>
 
 <template>
@@ -192,7 +192,7 @@ async function deleteAssignment(num: number, clsId: string): Promise<void> {
                                 >
                                     <v-list-item-content>
                                         <v-list-item-title
-                                        >{{ member.firstName + " " + member.lastName }}
+                                            >{{ member.firstName + " " + member.lastName }}
                                         </v-list-item-title>
                                     </v-list-item-content>
                                 </v-list-item>
@@ -202,9 +202,8 @@ async function deleteAssignment(num: number, clsId: string): Promise<void> {
                             <v-btn
                                 color="primary"
                                 @click="dialog = false"
-                            >Close
-                            </v-btn
-                            >
+                                >Close
+                            </v-btn>
                         </v-card-actions>
                     </v-card>
                 </v-dialog>
@@ -225,10 +224,10 @@ async function deleteAssignment(num: number, clsId: string): Promise<void> {
 </template>
 
 <style scoped>
-@import "@/assets/assignment.css";
+    @import "@/assets/assignment.css";
 
-.table-scroll {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-}
+    .table-scroll {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
 </style>


### PR DESCRIPTION
Deze PR fixt het probleem waarbij de link naar het leerpad niet meer werd getoond als de taal van de website veranderde en het leerpad in een andere taal was aangemaakt.

## Context
geen
## Screenshots
geen
## Aanvullende opmerkingen
- Fixes #226 
