### PR TITLE
feat: Progess voor leerpaden uit de Dwengo API

### DIFF
--- a/backend/src/services/learning-paths/database-learning-path-provider.ts
+++ b/backend/src/services/learning-paths/database-learning-path-provider.ts
@@ -4,7 +4,7 @@ import { getLearningPathRepository } from '../../data/repositories.js';
 import learningObjectService from '../learning-objects/learning-object-service.js';
 import { LearningPathNode } from '../../entities/content/learning-path-node.entity.js';
 import { LearningPathTransition } from '../../entities/content/learning-path-transition.entity.js';
-import { getLastSubmissionForGroup, isTransitionPossible } from './learning-path-personalization-util.js';
+import { getLastSubmissionForGroup, idFromLearningPathNode, isTransitionPossible } from './learning-path-personalization-util.js';
 import {
     FilteredLearningObject,
     LearningObjectNode,
@@ -95,7 +95,7 @@ async function convertNode(
     personalizedFor: Group | undefined,
     nodesToLearningObjects: Map<LearningPathNode, FilteredLearningObject>
 ): Promise<LearningObjectNode> {
-    const lastSubmission = personalizedFor ? await getLastSubmissionForGroup(node, personalizedFor) : null;
+    const lastSubmission = personalizedFor ? await getLastSubmissionForGroup(idFromLearningPathNode(node), personalizedFor) : null;
     const transitions = node.transitions
         .filter(
             (trans) =>

--- a/backend/src/services/learning-paths/dwengo-api-learning-path-provider.ts
+++ b/backend/src/services/learning-paths/dwengo-api-learning-path-provider.ts
@@ -3,11 +3,33 @@ import { DWENGO_API_BASE } from '../../config.js';
 import { LearningPathProvider } from './learning-path-provider.js';
 import { getLogger, Logger } from '../../logging/initalize.js';
 import { LearningPath, LearningPathResponse } from '@dwengo-1/common/interfaces/learning-content';
+import { Group } from '../../entities/assignments/group.entity.js';
+import { getLastSubmissionForGroup, idFromLearningObjectNode } from './learning-path-personalization-util.js';
 
 const logger: Logger = getLogger();
 
+/**
+ * Adds progress information to the learning path. Modifies the learning path in-place.
+ * @param learningPath The learning path to add progress to.
+ * @param personalizedFor The group whose progress should be shown.
+ * @returns the modified learning path.
+ */
+async function addProgressToLearningPath(learningPath: LearningPath, personalizedFor: Group): Promise<LearningPath> {
+    await Promise.all(
+        learningPath.nodes.map(async node => {
+            const lastSubmission = personalizedFor ? await getLastSubmissionForGroup(idFromLearningObjectNode(node), personalizedFor) : null
+            node.done = Boolean(lastSubmission);
+        })
+    );
+
+    learningPath.num_nodes = learningPath.nodes.length;
+    learningPath.num_nodes_left = learningPath.nodes.filter(it => !it.done).length;
+
+    return learningPath;
+}
+
 const dwengoApiLearningPathProvider: LearningPathProvider = {
-    async fetchLearningPaths(hruids: string[], language: string, source: string): Promise<LearningPathResponse> {
+    async fetchLearningPaths(hruids: string[], language: string, source: string, personalizedFor: Group): Promise<LearningPathResponse> {
         if (hruids.length === 0) {
             return {
                 success: false,
@@ -32,17 +54,29 @@ const dwengoApiLearningPathProvider: LearningPathProvider = {
             };
         }
 
+        await Promise.all(
+            learningPaths?.map(async it => addProgressToLearningPath(it, personalizedFor))
+        );
+
         return {
             success: true,
             source,
             data: learningPaths,
         };
     },
-    async searchLearningPaths(query: string, language: string): Promise<LearningPath[]> {
+    async searchLearningPaths(query: string, language: string, personalizedFor: Group): Promise<LearningPath[]> {
         const apiUrl = `${DWENGO_API_BASE}/learningPath/search`;
         const params = { all: query, language };
 
         const searchResults = await fetchWithLogging<LearningPath[]>(apiUrl, `Search learning paths with query "${query}"`, { params });
+
+        if (searchResults) {
+            await Promise.all(
+                searchResults?.map(async it => addProgressToLearningPath(it, personalizedFor))
+            );
+        }
+
+
         return searchResults ?? [];
     },
 };

--- a/backend/src/services/learning-paths/dwengo-api-learning-path-provider.ts
+++ b/backend/src/services/learning-paths/dwengo-api-learning-path-provider.ts
@@ -16,14 +16,14 @@ const logger: Logger = getLogger();
  */
 async function addProgressToLearningPath(learningPath: LearningPath, personalizedFor: Group): Promise<LearningPath> {
     await Promise.all(
-        learningPath.nodes.map(async node => {
-            const lastSubmission = personalizedFor ? await getLastSubmissionForGroup(idFromLearningObjectNode(node), personalizedFor) : null
+        learningPath.nodes.map(async (node) => {
+            const lastSubmission = personalizedFor ? await getLastSubmissionForGroup(idFromLearningObjectNode(node), personalizedFor) : null;
             node.done = Boolean(lastSubmission);
         })
     );
 
     learningPath.num_nodes = learningPath.nodes.length;
-    learningPath.num_nodes_left = learningPath.nodes.filter(it => !it.done).length;
+    learningPath.num_nodes_left = learningPath.nodes.filter((it) => !it.done).length;
 
     return learningPath;
 }
@@ -54,9 +54,7 @@ const dwengoApiLearningPathProvider: LearningPathProvider = {
             };
         }
 
-        await Promise.all(
-            learningPaths?.map(async it => addProgressToLearningPath(it, personalizedFor))
-        );
+        await Promise.all(learningPaths?.map(async (it) => addProgressToLearningPath(it, personalizedFor)));
 
         return {
             success: true,
@@ -71,11 +69,8 @@ const dwengoApiLearningPathProvider: LearningPathProvider = {
         const searchResults = await fetchWithLogging<LearningPath[]>(apiUrl, `Search learning paths with query "${query}"`, { params });
 
         if (searchResults) {
-            await Promise.all(
-                searchResults?.map(async it => addProgressToLearningPath(it, personalizedFor))
-            );
+            await Promise.all(searchResults?.map(async (it) => addProgressToLearningPath(it, personalizedFor)));
         }
-
 
         return searchResults ?? [];
     },

--- a/backend/src/services/learning-paths/learning-path-personalization-util.ts
+++ b/backend/src/services/learning-paths/learning-path-personalization-util.ts
@@ -22,8 +22,8 @@ export function idFromLearningObjectNode(node: LearningObjectNode): LearningObje
     return {
         hruid: node.learningobject_hruid,
         language: node.language,
-        version: node.version
-    }
+        version: node.version,
+    };
 }
 
 /**
@@ -33,8 +33,8 @@ export function idFromLearningPathNode(node: LearningPathNode): LearningObjectId
     return {
         hruid: node.learningObjectHruid,
         language: node.language,
-        version: node.version
-    }
+        version: node.version,
+    };
 }
 
 /**

--- a/backend/src/services/learning-paths/learning-path-personalization-util.ts
+++ b/backend/src/services/learning-paths/learning-path-personalization-util.ts
@@ -5,18 +5,36 @@ import { getSubmissionRepository } from '../../data/repositories.js';
 import { LearningObjectIdentifier } from '../../entities/content/learning-object-identifier.js';
 import { LearningPathTransition } from '../../entities/content/learning-path-transition.entity.js';
 import { JSONPath } from 'jsonpath-plus';
+import { LearningObjectNode } from '@dwengo-1/common/interfaces/learning-content';
 
 /**
  * Returns the last submission for the learning object associated with the given node and for the group
  */
-export async function getLastSubmissionForGroup(node: LearningPathNode, pathFor: Group): Promise<Submission | null> {
+export async function getLastSubmissionForGroup(learningObjectId: LearningObjectIdentifier, pathFor: Group): Promise<Submission | null> {
     const submissionRepo = getSubmissionRepository();
-    const learningObjectId: LearningObjectIdentifier = {
+    return await submissionRepo.findMostRecentSubmissionForGroup(learningObjectId, pathFor);
+}
+
+/**
+ * Creates a LearningObjectIdentifier describing the specified node.
+ */
+export function idFromLearningObjectNode(node: LearningObjectNode): LearningObjectIdentifier {
+    return {
+        hruid: node.learningobject_hruid,
+        language: node.language,
+        version: node.version
+    }
+}
+
+/**
+ * Creates a LearningObjectIdentifier describing the specified node.
+ */
+export function idFromLearningPathNode(node: LearningPathNode): LearningObjectIdentifier {
+    return {
         hruid: node.learningObjectHruid,
         language: node.language,
-        version: node.version,
-    };
-    return await submissionRepo.findMostRecentSubmissionForGroup(learningObjectId, pathFor);
+        version: node.version
+    }
 }
 
 /**


### PR DESCRIPTION
Tot nu toe werden de progress-attributen (`done` op leerobjecten, `num_nodes_left` op leerpaden) door ons backend voor leerpaden uit de Dwengo API nog niet teruggegeven. Deze PR zorgt ervoor dat dit wel gebeurt.

## Context

Deze PR was de oorzaak voor het probleem dat er op leerpaden uit de Dwengo API geen groene vinkjes voor *completed* leerobjecten getoond werd (#253). Bovendien zal dit na het mergen van #247 ook ervoor zorgen dat de progress bar werkt voor opdrachten met leerpaden uit de Dwengo API.

## Screenshots
n.v.t.

## Aanvullende opmerkingen

<!-- Voeg eventuele andere informatie toe waarvan reviewers op de hoogte moeten zijn. -->

<!-- Lijst eventuele gerelateerde issues. Gebruik het formaat `Fixes #<issue_number>` om het issue automatisch te sluiten wanneer de PR wordt gemerged. -->
- Fixes #253

<!--
## Richtlijnen

Zorg ervoor dat het volgende in orde is voordat je de pull request indient:

- De code volgt de stijlrichtlijnen van dit project.
- Je hebt een zelfreview van de code uitgevoerd.
- Je hebt de documentatie bijgewerkt waar nodig.
- Alle nieuwe en bestaande unittests slagen (lokaal).
- Je hebt de juiste labels ingesteld op deze pull request.
-->
