### PR TITLE
fix: Leerpaden voor thema's opvragen in de juiste taal

### DIFF
--- a/frontend/src/controllers/learning-paths.ts
+++ b/frontend/src/controllers/learning-paths.ts
@@ -26,8 +26,8 @@ export class LearningPathController extends BaseController {
         });
         return LearningPath.fromDTO(single(dtos));
     }
-    async getAllByTheme(theme: string): Promise<LearningPath[]> {
-        const dtos = await this.get<LearningPathDTO[]>("/", { theme });
+    async getAllByThemeAndLanguage(theme: string, language: Language): Promise<LearningPath[]> {
+        const dtos = await this.get<LearningPathDTO[]>("/", { theme, language });
         return dtos.map((dto) => LearningPath.fromDTO(dto));
     }
 

--- a/frontend/src/queries/learning-paths.ts
+++ b/frontend/src/queries/learning-paths.ts
@@ -24,7 +24,7 @@ export function useGetLearningPathQuery(
 
 export function useGetAllLearningPathsByThemeAndLanguageQuery(
     theme: MaybeRefOrGetter<string>,
-    language: MaybeRefOrGetter<Language>
+    language: MaybeRefOrGetter<Language>,
 ): UseQueryReturnType<LearningPath[], Error> {
     return useQuery({
         queryKey: [LEARNING_PATH_KEY, "getAllByTheme", theme, language],

--- a/frontend/src/queries/learning-paths.ts
+++ b/frontend/src/queries/learning-paths.ts
@@ -22,12 +22,13 @@ export function useGetLearningPathQuery(
     });
 }
 
-export function useGetAllLearningPathsByThemeQuery(
+export function useGetAllLearningPathsByThemeAndLanguageQuery(
     theme: MaybeRefOrGetter<string>,
+    language: MaybeRefOrGetter<Language>
 ): UseQueryReturnType<LearningPath[], Error> {
     return useQuery({
-        queryKey: [LEARNING_PATH_KEY, "getAllByTheme", theme],
-        queryFn: async () => learningPathController.getAllByTheme(toValue(theme)),
+        queryKey: [LEARNING_PATH_KEY, "getAllByTheme", theme, language],
+        queryFn: async () => learningPathController.getAllByThemeAndLanguage(toValue(theme), toValue(language)),
         enabled: () => Boolean(toValue(theme)),
     });
 }

--- a/frontend/src/views/SingleTheme.vue
+++ b/frontend/src/views/SingleTheme.vue
@@ -2,10 +2,11 @@
     import type { LearningPath } from "@/data-objects/learning-paths/learning-path.ts";
     import LearningPathsGrid from "@/components/LearningPathsGrid.vue";
     import UsingQueryResult from "@/components/UsingQueryResult.vue";
-    import { useGetAllLearningPathsByThemeQuery } from "@/queries/learning-paths.ts";
+    import { useGetAllLearningPathsByThemeAndLanguageQuery } from "@/queries/learning-paths.ts";
     import { computed, ref } from "vue";
     import { useI18n } from "vue-i18n";
     import { useThemeQuery } from "@/queries/themes.ts";
+import type { Language } from "@/data-objects/language";
 
     const props = defineProps<{ theme: string }>();
 
@@ -16,7 +17,7 @@
 
     const currentThemeInfo = computed(() => themeQueryResult.data.value?.find((it) => it.key === props.theme));
 
-    const learningPathsForThemeQueryResult = useGetAllLearningPathsByThemeQuery(() => props.theme);
+    const learningPathsForThemeQueryResult = useGetAllLearningPathsByThemeAndLanguageQuery(() => props.theme, () => locale.value as Language);
 
     const { t } = useI18n();
     const searchFilter = ref("");

--- a/frontend/src/views/SingleTheme.vue
+++ b/frontend/src/views/SingleTheme.vue
@@ -6,7 +6,7 @@
     import { computed, ref } from "vue";
     import { useI18n } from "vue-i18n";
     import { useThemeQuery } from "@/queries/themes.ts";
-import type { Language } from "@/data-objects/language";
+    import type { Language } from "@/data-objects/language";
 
     const props = defineProps<{ theme: string }>();
 
@@ -17,7 +17,10 @@ import type { Language } from "@/data-objects/language";
 
     const currentThemeInfo = computed(() => themeQueryResult.data.value?.find((it) => it.key === props.theme));
 
-    const learningPathsForThemeQueryResult = useGetAllLearningPathsByThemeAndLanguageQuery(() => props.theme, () => locale.value as Language);
+    const learningPathsForThemeQueryResult = useGetAllLearningPathsByThemeAndLanguageQuery(
+        () => props.theme,
+        () => locale.value as Language,
+    );
 
     const { t } = useI18n();
     const searchFilter = ref("");

--- a/frontend/tests/controllers/learning-paths-controller.test.ts
+++ b/frontend/tests/controllers/learning-paths-controller.test.ts
@@ -15,7 +15,7 @@ describe("Test controller learning paths", () => {
     });
 
     it("Can get learning path by id", async () => {
-        const data = await controller.getAllByTheme("kiks");
+        const data = await controller.getAllByThemeAndLanguage("kiks", Language.Dutch);
         expect(data).to.have.length.greaterThan(0);
     });
 });


### PR DESCRIPTION
Deze PR zorgt ervoor dat op de `SingleTheme.vue` pagina de leerpaden in de ingestelde taal opgevraagd en getoond worden.

## Context

Vroeger werd bij het opvragen van de leerpaden geen `language` query parameter meegegeven, waardoor standaard altijd enkel de Nederlandstalige leerpaden opgevraagd werden (zie #264)

## Screenshots

![grafik](https://github.com/user-attachments/assets/2978ec5b-c596-41a3-9d31-773dc2196d40)
![grafik](https://github.com/user-attachments/assets/389b567f-bf12-42e6-8091-f3f5f3f84098)
![grafik](https://github.com/user-attachments/assets/324bc8c8-9eb7-46b2-bb56-3d6f36c3f14d)

## Aanvullende opmerkingen

<!-- Voeg eventuele andere informatie toe waarvan reviewers op de hoogte moeten zijn. -->

<!-- Lijst eventuele gerelateerde issues. Gebruik het formaat `Fixes #<issue_number>` om het issue automatisch te sluiten wanneer de PR wordt gemerged. -->
- Fixes #264 

<!--
## Richtlijnen

Zorg ervoor dat het volgende in orde is voordat je de pull request indient:

- De code volgt de stijlrichtlijnen van dit project.
- Je hebt een zelfreview van de code uitgevoerd.
- Je hebt de documentatie bijgewerkt waar nodig.
- Alle nieuwe en bestaande unittests slagen (lokaal).
- Je hebt de juiste labels ingesteld op deze pull request.
-->
