### PR TITLE
fix: Ellipsis bevestigingsdialoog logout

### DIFF
--- a/frontend/src/components/MenuBar.vue
+++ b/frontend/src/components/MenuBar.vue
@@ -149,7 +149,8 @@
             </template>
 
             <template v-slot:default="{ isActive }">
-                <v-card :title="t('logoutVerification')">
+                <v-card>
+                    <v-card-title class="logout-verification-title">{{ t('logoutVerification')  }}</v-card-title>
                     <v-card-actions>
                         <v-spacer></v-spacer>
 
@@ -296,6 +297,13 @@
         z-index: 1;
         position: relative;
         margin-left: 10px;
+    }
+
+    .logout-verification-title {
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+        white-space: normal;
+        text-overflow: unset;
     }
 
     @media (max-width: 700px) {

--- a/frontend/src/components/MenuBar.vue
+++ b/frontend/src/components/MenuBar.vue
@@ -150,7 +150,7 @@
 
             <template v-slot:default="{ isActive }">
                 <v-card>
-                    <v-card-title class="logout-verification-title">{{ t('logoutVerification')  }}</v-card-title>
+                    <v-card-title class="logout-verification-title">{{ t("logoutVerification") }}</v-card-title>
                     <v-card-actions>
                         <v-spacer></v-spacer>
 


### PR DESCRIPTION
Deze PR zorgt ervoor dat de tekst in de bevestigingsdialoog bij het uitloggen ("Bent u zeker dat u wilt uitloggen?") niet meer met een ellipsis afgekapt wordt, maar correct wordt afgebroken naar de volgende regel.
## Context
n.v.t.

## Screenshots
![Bildschirmfoto vom 2025-05-18 02-12-10](https://github.com/user-attachments/assets/7f763c88-f8ed-4a30-9345-1965947801ff)

<!-- Voeg indien van toepassing screenshots toe om je wijzigingen uit te leggen. -->

## Aanvullende opmerkingen

<!-- Voeg eventuele andere informatie toe waarvan reviewers op de hoogte moeten zijn. -->

<!-- Lijst eventuele gerelateerde issues. Gebruik het formaat `Fixes #<issue_number>` om het issue automatisch te sluiten wanneer de PR wordt gemerged. -->
- Fixes #279 

<!--
## Richtlijnen

Zorg ervoor dat het volgende in orde is voordat je de pull request indient:

- De code volgt de stijlrichtlijnen van dit project.
- Je hebt een zelfreview van de code uitgevoerd.
- Je hebt de documentatie bijgewerkt waar nodig.
- Alle nieuwe en bestaande unittests slagen (lokaal).
- Je hebt de juiste labels ingesteld op deze pull request.
-->
