### PR TITLE
fix: Kleine verbeteringen omtrent eigen leerpaden

### DIFF
--- a/frontend/src/views/own-learning-content/learning-paths/LearningPathPreviewCard.vue
+++ b/frontend/src/views/own-learning-content/learning-paths/LearningPathPreviewCard.vue
@@ -89,6 +89,15 @@
                 props.selectedLearningPath.language !== parsedLearningPath.value.language),
     );
 
+    const selectedLearningPathLink = computed(() => {
+        if (!props.selectedLearningPath) {
+            return undefined;
+        }
+        const { hruid, language } = props.selectedLearningPath;
+        const startNode = props.selectedLearningPath.nodes.find((it) => it.start_node);
+        return `/learningPath/${hruid}/${language}/${startNode.learningobject_hruid}`;
+    });
+
     function getErrorMessage(): string | null {
         if (postError.value) {
             return t(extractErrorMessage(postError.value));
@@ -128,7 +137,7 @@
                         variant="text"
                     />
                     <v-btn
-                        :href="`/learningPath/${props.selectedLearningPath?.hruid}/${props.selectedLearningPath?.language}/start`"
+                        :href="selectedLearningPathLink"
                         target="_blank"
                         prepend-icon="mdi mdi-open-in-new"
                         :disabled="!props.selectedLearningPath"

--- a/frontend/src/views/own-learning-content/learning-paths/LearningPathPreviewCard.vue
+++ b/frontend/src/views/own-learning-content/learning-paths/LearningPathPreviewCard.vue
@@ -104,7 +104,41 @@
 </script>
 
 <template>
-    <v-card :title="props.selectedLearningPath ? t('editLearningPath') : t('newLearningPath')">
+    <v-card>
+        <template v-slot:title>
+            <div class="title-container">
+                <span class="title">{{ props.selectedLearningPath ? t('editLearningPath') : t('newLearningPath') }}</span>
+                <span class="actions">
+                    <v-btn
+                        @click="uploadLearningPath"
+                        prependIcon="mdi mdi-check"
+                        :loading="isPostPending || isPutPending"
+                        :disabled="parsedLearningPath.hruid === DEFAULT_LEARNING_PATH.hruid || isIdModified"
+                        variant="text"
+                    >
+                        {{ props.selectedLearningPath ? t("saveChanges") : t("create") }}
+                    </v-btn>
+                    <button-with-confirmation
+                        @confirm="deleteLearningPath"
+                        :disabled="!props.selectedLearningPath"
+                        :text="t('delete')"
+                        color="red"
+                        prependIcon="mdi mdi-delete"
+                        :confirmQueryText="t('learningPathDeleteQuery')"
+                        variant="text"
+                    />
+                    <v-btn
+                        :href="`/learningPath/${props.selectedLearningPath?.hruid}/${props.selectedLearningPath?.language}/start`"
+                        target="_blank"
+                        prepend-icon="mdi mdi-open-in-new"
+                        :disabled="!props.selectedLearningPath"
+                        variant="text"
+                    >
+                        {{ t("open") }}
+                    </v-btn>
+                </span>
+            </div>
+        </template>
         <template v-slot:text>
             <json-editor-vue v-model="learningPath"></json-editor-vue>
             <v-alert
@@ -115,33 +149,21 @@
                 :text="getErrorMessage()!"
             ></v-alert>
         </template>
-        <template v-slot:actions>
-            <v-btn
-                @click="uploadLearningPath"
-                prependIcon="mdi mdi-check"
-                :loading="isPostPending || isPutPending"
-                :disabled="parsedLearningPath.hruid === DEFAULT_LEARNING_PATH.hruid || isIdModified"
-            >
-                {{ props.selectedLearningPath ? t("saveChanges") : t("create") }}
-            </v-btn>
-            <button-with-confirmation
-                @confirm="deleteLearningPath"
-                :disabled="!props.selectedLearningPath"
-                :text="t('delete')"
-                color="red"
-                prependIcon="mdi mdi-delete"
-                :confirmQueryText="t('learningPathDeleteQuery')"
-            />
-            <v-btn
-                :href="`/learningPath/${props.selectedLearningPath?.hruid}/${props.selectedLearningPath?.language}/start`"
-                target="_blank"
-                prepend-icon="mdi mdi-open-in-new"
-                :disabled="!props.selectedLearningPath"
-            >
-                {{ t("open") }}
-            </v-btn>
-        </template>
     </v-card>
 </template>
 
-<style scoped></style>
+<style scoped>
+    .title-container {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+    .title {
+        flex: 1;
+    }
+    .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+    }
+</style>

--- a/frontend/src/views/own-learning-content/learning-paths/LearningPathPreviewCard.vue
+++ b/frontend/src/views/own-learning-content/learning-paths/LearningPathPreviewCard.vue
@@ -116,7 +116,9 @@
     <v-card>
         <template v-slot:title>
             <div class="title-container">
-                <span class="title">{{ props.selectedLearningPath ? t('editLearningPath') : t('newLearningPath') }}</span>
+                <span class="title">{{
+                    props.selectedLearningPath ? t("editLearningPath") : t("newLearningPath")
+                }}</span>
                 <span class="actions">
                     <v-btn
                         @click="uploadLearningPath"


### PR DESCRIPTION
Deze PR
* zorgt ervoor dat op de "eigen leerpaden"-pagina de actieknoppen *Create/Save changes*, *Delete* en *Open* voor leerpaden boven i.p.v. onder de JSON-editor staan,
* zorgt ervoor dat de leerpadpagina initieel het eerste leerobject op het pad toont wanneer een leerpad wordt geopend vanuit de "eigen leerpaden"-pagina.

## Context

* Tot nu toe staan de actieknoppen bij leerpaden onderaan, waardoor er voor lange leerpaden veel gescrolled moet worden. (#287)
* De knop *Open* leidde tot nu toe wel al naar de juiste leerpadpagina, maar het eerste leerobject werd niet automatisch geopend. Dat wordt in deze PR aangepast. (#288)

## Screenshots
De actieknoppen bevinden zich nu bovenaan:
![grafik](https://github.com/user-attachments/assets/924d6215-d29d-4bbf-a678-6b55f56f27da)

## Aanvullende opmerkingen

<!-- Voeg eventuele andere informatie toe waarvan reviewers op de hoogte moeten zijn. -->

<!-- Lijst eventuele gerelateerde issues. Gebruik het formaat `Fixes #<issue_number>` om het issue automatisch te sluiten wanneer de PR wordt gemerged. -->
- Fixes #287 
- Fixes #288

<!--
## Richtlijnen

Zorg ervoor dat het volgende in orde is voordat je de pull request indient:

- De code volgt de stijlrichtlijnen van dit project.
- Je hebt een zelfreview van de code uitgevoerd.
- Je hebt de documentatie bijgewerkt waar nodig.
- Alle nieuwe en bestaande unittests slagen (lokaal).
- Je hebt de juiste labels ingesteld op deze pull request.
-->
