### PR TITLE
feat: enkel content scrollable, niet titels, knoppen, ...

### DIFF
--- a/frontend/src/components/DiscussionsSideBar.vue
+++ b/frontend/src/components/DiscussionsSideBar.vue
@@ -34,19 +34,21 @@
                 </template>
             </v-list-item>
             <v-divider></v-divider>
-            <v-expansion-panels v-model="expanded">
-                <using-query-result
-                    :query-result="allLearningPathsResult"
-                    v-slot="learningPaths: { data: LearningPath[] }"
-                >
-                    <DiscussionSideBarElement
-                        v-for="learningPath in learningPaths.data"
-                        :path="learningPath"
-                        :activeObjectId="'' as string"
-                        :key="learningPath.hruid"
-                    />
-                </using-query-result>
-            </v-expansion-panels>
+            <div class="nav-scroll-area">
+                <v-expansion-panels v-model="expanded">
+                    <using-query-result
+                        :query-result="allLearningPathsResult"
+                        v-slot="learningPaths: { data: LearningPath[] }"
+                    >
+                        <DiscussionSideBarElement
+                            v-for="learningPath in learningPaths.data"
+                            :path="learningPath"
+                            :activeObjectId="'' as string"
+                            :key="learningPath.hruid"
+                        />
+                    </using-query-result>
+                </v-expansion-panels>
+            </div>
         </div>
     </v-navigation-drawer>
     <div class="control-bar-above-content">
@@ -66,5 +68,11 @@
         font-weight: bolder;
         padding-top: 2%;
         font-size: 36px;
+    }
+
+    .nav-scroll-area {
+        overflow-y: auto;
+        flex-grow: 1;
+        min-height: 0;
     }
 </style>

--- a/frontend/src/views/learning-paths/LearningPathPage.vue
+++ b/frontend/src/views/learning-paths/LearningPathPage.vue
@@ -229,7 +229,7 @@
                     </template>
                 </v-list-item>
                 <v-divider></v-divider>
-                <div>
+                <div class="nav-scroll-area">
                     <using-query-result
                         :query-result="learningObjectListQueryResult"
                         v-slot="learningObjects: { data: LearningObject[] }"
@@ -416,5 +416,11 @@
 
     .discussion-link a:hover {
         text-decoration: underline;
+    }
+
+    .nav-scroll-area {
+        overflow-y: auto;
+        flex-grow: 1;
+        min-height: 0;
     }
 </style>


### PR DESCRIPTION
<!-- Beschrijf wat deze pull request doet. Voeg een samenvatting van de wijzigingen en de reden voor de wijzigingen toe. -->
Deze pull request zorgt ervoor dat de content in de sidebar van leerpaden en discussions scrollable blijft, maar dat de knop waarmee een leerkracht een assingment kan geven, en de titels op een fixed position blijven staan.
## Context

<!-- Geef extra context en uitleg waarom bepaalde keuzes zijn gemaakt in deze pull request. -->

## Screenshots

<!-- Voeg indien van toepassing screenshots toe om je wijzigingen uit te leggen. -->
[Screencast from 2025-05-20 09-38-19.webm](https://github.com/user-attachments/assets/ec77868f-fe08-49c5-9775-998fd0efc79b)

![image](https://github.com/user-attachments/assets/b515c2ae-3f09-470b-a96e-6f63516c3255)

## Aanvullende opmerkingen

<!-- Voeg eventuele andere informatie toe waarvan reviewers op de hoogte moeten zijn. -->

<!-- Lijst eventuele gerelateerde issues. Gebruik het formaat `Fixes #<issue_number>` om het issue automatisch te sluiten wanneer de PR wordt gemerged. -->
- Fixes #291 

<!--
## Richtlijnen

Zorg ervoor dat het volgende in orde is voordat je de pull request indient:

- De code volgt de stijlrichtlijnen van dit project.
- Je hebt een zelfreview van de code uitgevoerd.
- Je hebt de documentatie bijgewerkt waar nodig.
- Alle nieuwe en bestaande unittests slagen (lokaal).
- Je hebt de juiste labels ingesteld op deze pull request.
-->
